### PR TITLE
Fixed typo in ordering

### DIFF
--- a/src/main/scala/org/economicsl/mechanisms/voting-mechanisms.sc
+++ b/src/main/scala/org/economicsl/mechanisms/voting-mechanisms.sc
@@ -7,7 +7,8 @@ import collection.{GenMap, GenSet, parallel}
 
 case class Ballot(signature: UUID, alternative: Alternative) extends Preference[Alternative] {
 
-  val ordering: Ordering[Alternative] = Ordering.by(a => if (a == alternative) 1 else 0)
+  // Insures that the head of any sorted collection of alternatives is the preferred alternative!
+  val ordering: Ordering[Alternative] = Ordering.by(a => if (a == alternative) 0 else 1)
 
 }
 


### PR DESCRIPTION
Want to makes certain that if the ordering is used to sort a collection of alternatives, the preferred alternative will be the head element.