### PR TITLE
Added a factory method for create Preference monoids

### DIFF
--- a/src/main/scala/org/economicsl/mechanisms/Preference.scala
+++ b/src/main/scala/org/economicsl/mechanisms/Preference.scala
@@ -122,8 +122,8 @@ object Preference {
   }
 
 
-  def leftBiasedWhenIndifferent[A]: Monoid[Preference[A]] = {
-    monoid(leftBiasedWhenEmpty)
+  def leftBiased[A]: Monoid[Preference[A]] = {
+    monoid(_leftBiased)
   }
 
   /** Return a `Monoid[Preference[A]]` instance that combines two `Preference[A]`
@@ -131,11 +131,11 @@ object Preference {
     * second preference instance and then uses the first preference instance to
     * break ties.
     */
-  def rightBiasedWhenIndifferent[A]: Monoid[Preference[A]] = {
-    monoid(rightBiasedWhenEmpty)
+  def rightBiased[A]: Monoid[Preference[A]] = {
+    monoid(_rightBiased)
   }
 
-  private def leftBiasedWhenEmpty[A]: Monoid[(A, A) => Int] = {
+  private def _leftBiased[A]: Monoid[(A, A) => Int] = {
     new Monoid[(A, A) => Int] {
       def combine(c1: (A, A) => Int, c2: (A, A) => Int): (A, A) => Int = {
         (a1, a2) => if (c1(a1, a2) == 0) c2(a1, a2) else c1(a1, a2)
@@ -146,7 +146,7 @@ object Preference {
     }
   }
 
-  private def rightBiasedWhenEmpty[A]: Monoid[(A, A) => Int] = {
+  private def _rightBiased[A]: Monoid[(A, A) => Int] = {
     new Monoid[(A, A) => Int] {
       def combine(c1: (A, A) => Int, c2: (A, A) => Int): (A, A) => Int = {
         (a1, a2) => if (c2(a1, a2) == 0) c1(a1, a2) else c2(a1, a2)

--- a/src/main/scala/org/economicsl/mechanisms/Preference.scala
+++ b/src/main/scala/org/economicsl/mechanisms/Preference.scala
@@ -53,6 +53,14 @@ object Preference {
     }
   }
 
+  def from[A](f: (A, A) => Int): Preference[A] = {
+    new Preference[A] {
+      def compare(a1: A, a2: A): Int = {
+        f(a1, a2)
+      }
+    }
+  }
+
   /** Assumes that alternatives are ordered from least to most preferred. */
   def fromSeq[A](alternatives: Seq[A]): Preference[A] = {
     new Preference[A] {
@@ -66,6 +74,21 @@ object Preference {
     new Preference[A] {
       def compare(a1: A, a2: A): Int = {
         0
+      }
+    }
+  }
+
+  def monoid[A](implicit ev: Monoid[(A, A) => Int]): Monoid[Preference[A]] = {
+    new Monoid[Preference[A]] {
+      def combine(p1: Preference[A], p2: Preference[A]): Preference[A] = {
+        new Preference[A] {
+          def compare(a1: A, a2: A): Int = {
+            ev.combine(p1.compare, p2.compare)(a1, a2)
+          }
+        }
+      }
+      val empty: Preference[A] = {
+        from(ev.empty)
       }
     }
   }

--- a/src/main/scala/org/economicsl/mechanisms/Preference.scala
+++ b/src/main/scala/org/economicsl/mechanisms/Preference.scala
@@ -108,29 +108,43 @@ object Preference {
     }
   }
 
-  /** Returns a new `Preference[A]` instance that compares using the first
-    * `Preference` instance and then uses the second `Preference` instance to
-    * "break ties".
+
+  /** Return a `Monoid[Preference[A]]` instance that combines two `Preference[A]`
+    * instances to create a new `Preference[A]` instance that compares using the
+    * first preference instance and then uses the second preference instance to
+    * break ties. The empty value
     */
-  def whenEqual[A](p1: Preference[A], p2: Preference[A]): Preference[A] = {
-    new Preference[A] {
-      def compare(a1: A, a2: A): Int = {
-        val c = p1.compare(a1, a2)
-        if (c == 0) p2.compare(a1, a2) else c
+  def leftBiasedWhenIndifferent[A]: Monoid[Preference[A]] = {
+    monoid(leftBiasedWhenEmpty)
+  }
+
+  /** Return a `Monoid[Preference[A]]` instance that combines two `Preference[A]`
+    * instances to create a new `Preference[A]` instance that compares using the
+    * second preference instance and then uses the first preference instance to
+    * break ties.
+    */
+  def rightBiasedWhenIndifferent[A]: Monoid[Preference[A]] = {
+    monoid(rightBiasedWhenEmpty)
+  }
+
+  private def leftBiasedWhenEmpty[A]: Monoid[(A, A) => Int] = {
+    new Monoid[(A, A) => Int] {
+      def combine(c1: (A, A) => Int, c2: (A, A) => Int): (A, A) => Int = {
+        (a1, a2) => if (c1(a1, a2) == 0) c2(a1, a2) else c1(a1, a2)
+      }
+      def empty: (A, A) => Int = {
+        (a1, a2) => 0
       }
     }
   }
 
-  /** A monoid instance can be generated for any `A` by using whenEqual as the
-    * combine method and indifference as the empty value.
-    */
-  def whenEqualMonoid[A]: Monoid[Preference[A]] = {
-    new Monoid[Preference[A]] {
-      def combine(p1: Preference[A], p2: Preference[A]): Preference[A] = {
-        whenEqual(p1, p2)
+  private def rightBiasedWhenEmpty[A]: Monoid[(A, A) => Int] = {
+    new Monoid[(A, A) => Int] {
+      def combine(c1: (A, A) => Int, c2: (A, A) => Int): (A, A) => Int = {
+        (a1, a2) => if (c2(a1, a2) == 0) c1(a1, a2) else c2(a1, a2)
       }
-      val empty: Preference[A] = {
-        indifference
+      def empty: (A, A) => Int = {
+        (a1, a2) => 0
       }
     }
   }

--- a/src/main/scala/org/economicsl/mechanisms/SocialWelfareFunction.scala
+++ b/src/main/scala/org/economicsl/mechanisms/SocialWelfareFunction.scala
@@ -29,15 +29,6 @@ trait SocialWelfareFunction[-CC <: Iterable[P], +P <: Preference[A], A]
 
 object SocialWelfareFunction {
 
-  def lexicographic[A]: SocialWelfareFunction[Iterable[Preference[A]], Preference[A], A] = {
-    new SocialWelfareFunction[Iterable[Preference[A]], Preference[A], A] {
-      def apply(preferences: Iterable[Preference[A]]): Preference[A] = {
-        preferences.reduce(Preference.leftBiasedWhenIndifferent[A].combine)
-      }
-    }
-  }
-
-  /** Define a `SocialWelfareFunction` using an available `Monoid[Preference[A]]`. */
   def fold[A](implicit ev: Monoid[Preference[A]]): SocialWelfareFunction[Iterable[Preference[A]], Preference[A], A] = {
     new SocialWelfareFunction[Iterable[Preference[A]], Preference[A], A] {
       def apply(preferences: Iterable[Preference[A]]): Preference[A] = {
@@ -46,7 +37,11 @@ object SocialWelfareFunction {
     }
   }
 
-  /** Define a `SocialWelfareFunction` using an available `Semigroup[Preference[A]]`. */
+  /** If the head element in the collection of preferences can strictly compare any two instances of type `A`, then head preference will be a dicator. */
+  def leftBiased[A]: SocialWelfareFunction[Iterable[Preference[A]], Preference[A], A] = {
+    fold(Preference.leftBiased)
+  }
+
   def reduce[A](implicit ev: Semigroup[Preference[A]]): SocialWelfareFunction[Iterable[Preference[A]], Preference[A], A] = {
     new SocialWelfareFunction[Iterable[Preference[A]], Preference[A], A] {
       def apply(preferences: Iterable[Preference[A]]): Preference[A] = {
@@ -54,4 +49,10 @@ object SocialWelfareFunction {
       }
     }
   }
+
+  /** If the last element in the collection of preferences can strictly compare any two instances of type `A`, then the last preference will be a dicator. */
+  def rightBiased[A]: SocialWelfareFunction[Iterable[Preference[A]], Preference[A], A] = {
+    fold(Preference.rightBiased[A])
+  }
+
 }

--- a/src/main/scala/org/economicsl/mechanisms/SocialWelfareFunction.scala
+++ b/src/main/scala/org/economicsl/mechanisms/SocialWelfareFunction.scala
@@ -30,7 +30,7 @@ object SocialWelfareFunction {
   def lexicographic[A]: SocialWelfareFunction[Iterable[Preference[A]], Preference[A], A] = {
     new SocialWelfareFunction[Iterable[Preference[A]], Preference[A], A] {
       def apply(preferences: Iterable[Preference[A]]): Preference[A] = {
-        preferences.reduce(Preference.whenEqual[A])
+        preferences.reduce(Preference.leftBiasedWhenIndifferent[A].combine)
       }
     }
   }

--- a/src/main/scala/org/economicsl/mechanisms/SocialWelfareFunction.scala
+++ b/src/main/scala/org/economicsl/mechanisms/SocialWelfareFunction.scala
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package org.economicsl.mechanisms
 
-import cats.Semigroup
+import cats.{Monoid, Semigroup}
 
 
 /** Base trait defining a generic social welfare function.
@@ -33,6 +33,15 @@ object SocialWelfareFunction {
     new SocialWelfareFunction[Iterable[Preference[A]], Preference[A], A] {
       def apply(preferences: Iterable[Preference[A]]): Preference[A] = {
         preferences.reduce(Preference.leftBiasedWhenIndifferent[A].combine)
+      }
+    }
+  }
+
+  /** Define a `SocialWelfareFunction` using an available `Monoid[Preference[A]]`. */
+  def fold[A](implicit ev: Monoid[Preference[A]]): SocialWelfareFunction[Iterable[Preference[A]], Preference[A], A] = {
+    new SocialWelfareFunction[Iterable[Preference[A]], Preference[A], A] {
+      def apply(preferences: Iterable[Preference[A]]): Preference[A] = {
+        preferences.fold(ev.empty)(ev.combine)
       }
     }
   }


### PR DESCRIPTION
Noted that it is possible to create a `Monoid[Preference[A]]` from a `Monoid[(A,A)=>Int]` and added a factory method to facilitate this. 