### PR TITLE
Add semigroup factory

### DIFF
--- a/src/main/scala/org/economicsl/mechanisms/Preference.scala
+++ b/src/main/scala/org/economicsl/mechanisms/Preference.scala
@@ -85,6 +85,19 @@ object Preference {
     }
   }
 
+  /** Derives a `Semigroup[Preference[A]]` instance from `Semigroup[(A, A) => Int]` instance. */
+  def semigroup[A](implicit ev: Semigroup[(A, A) => Int]): Semigroup[Preference[A]] = {
+    new Semigroup[Preference[A]] {
+      def combine(p1: Preference[A], p2: Preference[A]): Preference[A] = {
+        new Preference[A] {
+          def compare(a1: A, a2: A): Int = {
+            ev.combine(p1.compare, p2.compare)(a1, a2)
+          }
+        }
+      }
+    }
+  }
+
   /** Returns a new `Preference[A]` instance that compares using the first
     * `Preference` instance and then uses the second `Preference` instance to
     * "break ties".

--- a/src/main/scala/org/economicsl/mechanisms/SocialWelfareFunction.scala
+++ b/src/main/scala/org/economicsl/mechanisms/SocialWelfareFunction.scala
@@ -15,6 +15,8 @@ limitations under the License.
 */
 package org.economicsl.mechanisms
 
+import cats.Semigroup
+
 
 /** Base trait defining a generic social welfare function.
   *
@@ -31,6 +33,15 @@ object SocialWelfareFunction {
     new SocialWelfareFunction[Iterable[Preference[A]], Preference[A], A] {
       def apply(preferences: Iterable[Preference[A]]): Preference[A] = {
         preferences.reduce(Preference.whenEqual[A])
+      }
+    }
+  }
+
+  /** Define a `SocialWelfareFunction` using an available `Semigroup[Preference[A]]`. */
+  def reduce[A](implicit ev: Semigroup[Preference[A]]): SocialWelfareFunction[Iterable[Preference[A]], Preference[A], A] = {
+    new SocialWelfareFunction[Iterable[Preference[A]], Preference[A], A] {
+      def apply(preferences: Iterable[Preference[A]]): Preference[A] = {
+        preferences.reduce(ev.combine)
       }
     }
   }


### PR DESCRIPTION
This PR add a combinator for deriving `Semigroup[Preference[A]]` instances from `Semigroup[(A,A)=>Int]` instances.  